### PR TITLE
Importing GDShader and GDResource syntax definitions from official VSCode plugin

### DIFF
--- a/gdresource/GDResource.sublime-syntax
+++ b/gdresource/GDResource.sublime-syntax
@@ -1,0 +1,153 @@
+%YAML 1.2
+---
+# http://www.sublimetext.com/docs/3/syntax.html
+# Generated from the official godot VSCode tmlanguage.json file, modified to list file extensions
+name: GDResource
+file_extensions:
+  - godot
+  - tres
+  - import
+  - gdns
+  - gdnlib
+  - tscn
+scope: source.gdresource
+contexts:
+  main:
+    - include: embedded_shader
+    - include: embedded_gdscript
+    - include: comment
+    - include: heading
+    - include: key_value
+  comment:
+    - match: (;).*$\n?
+      scope: comment.line.gdresource
+      captures:
+        1: punctuation.definition.comment.gdresource
+  data:
+    - include: comment
+    - match: '(?<!\w)(\{)\s*'
+      captures:
+        1: punctuation.definition.table.inline.gdresource
+      push:
+        - match: '\s*(\})(?!\w)'
+          captures:
+            1: punctuation.definition.table.inline.gdresource
+          pop: true
+        - include: key_value
+        - include: data
+    - match: '(?<!\w)(\[)\s*'
+      captures:
+        1: punctuation.definition.array.gdresource
+      push:
+        - match: '\s*(\])(?!\w)'
+          captures:
+            1: punctuation.definition.array.gdresource
+          pop: true
+        - include: data
+    - match: '"""'
+      push:
+        - meta_scope: string.quoted.triple.basic.block.gdresource
+        - match: '"""'
+          pop: true
+        - match: '\\([btnfr"\\\n/ ]|u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{8})'
+          scope: constant.character.escape.gdresource
+        - match: '\\[^btnfr/"\\\n]'
+          scope: invalid.illegal.escape.gdresource
+    - match: '"res:\/\/[^"\\]*(?:\\.[^"\\]*)*"'
+      scope: support.function.any-method.gdresource
+    - match: '(?<=type=)"[^"\\]*(?:\\.[^"\\]*)*"'
+      scope: support.class.library.gdresource
+    - match: '(?<=NodePath\(|parent=|name=)"[^"\\]*(?:\\.[^"\\]*)*"'
+      scope: constant.character.escape.gdresource
+    - match: '"'
+      push:
+        - meta_scope: string.quoted.double.basic.line.gdresource
+        - match: '"'
+          pop: true
+        - match: '\\([btnfr"\\\n/ ]|u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{8})'
+          scope: constant.character.escape.gdresource
+        - match: '\\[^btnfr/"\\\n]'
+          scope: invalid.illegal.escape.gdresource
+    - match: "'.*?'"
+      scope: string.quoted.single.literal.line.gdresource
+    - match: (?<!\w)(true|false)(?!\w)
+      scope: constant.language.gdresource
+    - match: '(?<!\w)([\+\-]?(0|([1-9](([0-9]|_[0-9])+)?))(?:(?:\.(0|([1-9](([0-9]|_[0-9])+)?)))?[eE][\+\-]?[1-9]_?[0-9]*|(?:\.[0-9_]*)))(?!\w)'
+      scope: constant.numeric.float.gdresource
+    - match: '(?<!\w)((?:[\+\-]?(0|([1-9](([0-9]|_[0-9])+)?))))(?!\w)'
+      scope: constant.numeric.integer.gdresource
+    - match: '(?<!\w)([\+\-]?inf)(?!\w)'
+      scope: constant.numeric.inf.gdresource
+    - match: '(?<!\w)([\+\-]?nan)(?!\w)'
+      scope: constant.numeric.nan.gdresource
+    - match: '(?<!\w)((?:0x(([0-9a-fA-F](([0-9a-fA-F]|_[0-9a-fA-F])+)?))))(?!\w)'
+      scope: constant.numeric.hex.gdresource
+    - match: '(?<!\w)(0o[0-7](_?[0-7])*)(?!\w)'
+      scope: constant.numeric.oct.gdresource
+    - match: '(?<!\w)(0b[01](_?[01])*)(?!\w)'
+      scope: constant.numeric.bin.gdresource
+    - match: (?<!\w)(Vector2|Vector2i|Vector3|Vector3i|Color|Rect2|Rect2i|Array|Basis|Dictionary|Plane|Quat|RID|Rect3|Transform|Transform2D|Transform3D|AABB|String|Color|NodePath|Object|PoolByteArray|PoolIntArray|PoolRealArray|PoolStringArray|PoolVector2Array|PoolVector3Array|PoolColorArray|bool|int|float|StringName|Quaternion|PackedByteArray|PackedInt32Array|PackedInt64Array|PackedFloat32Array|PackedFloat64Array|PackedStringArray|PackedVector2Array|PackedVector2iArray|PackedVector3Array|PackedVector3iArray|PackedColorArray)(\()\s?
+      captures:
+        1: support.class.library.gdresource
+      push:
+        - match: \s?(\))
+          pop: true
+        - include: key_value
+        - include: data
+    - match: (?<!\w)(ExtResource|SubResource)(\()\s?
+      captures:
+        1: keyword.control.gdresource
+      push:
+        - match: \s?(\))
+          pop: true
+        - include: key_value
+        - include: data
+  embedded_gdscript:
+    - match: (script/source) = "
+      comment: meta.embedded.block.gdscript
+      captures:
+        1: variable.other.property.gdresource
+      push:
+        - match: '"'
+          pop: true
+        - include: scope:source.gdscript
+  embedded_shader:
+    - match: (code) = "
+      captures:
+        1: variable.other.property.gdresource
+      push:
+        - meta_scope: meta.embedded.block.gdshader
+        - match: '"'
+          pop: true
+        - include: scope:source.gdshader
+  heading:
+    - match: '\[([a-z_]*)\s?'
+      captures:
+        1: keyword.control.gdresource
+      push:
+        - match: '\]'
+          pop: true
+        - include: heading_properties
+        - include: data
+  heading_properties:
+    - match: '(\s*[A-Za-z_\-][A-Za-z0-9_\-]*\s*=)(?=\s*$)'
+      scope: invalid.illegal.noValue.gdresource
+    - match: '\s*([A-Za-z_-][^\s]*|".+"|''.+''|[0-9]+)\s*(=)\s*'
+      captures:
+        1: variable.other.property.gdresource
+        2: punctuation.definition.keyValue.gdresource
+      push:
+        - match: '($|(?==)|\,?|\s*(?=\}))'
+          pop: true
+        - include: data
+  key_value:
+    - match: '(\s*[A-Za-z_\-][A-Za-z0-9_\-]*\s*=)(?=\s*$)'
+      scope: invalid.illegal.noValue.gdresource
+    - match: '\s*([A-Za-z_-][^\s]*|".+"|''.+''|[0-9]+)\s*(=)\s*'
+      captures:
+        1: variable.other.property.gdresource
+        2: punctuation.definition.keyValue.gdresource
+      push:
+        - match: '($|(?==)|\,|\s*(?=\}))'
+          pop: true
+        - include: data

--- a/gdshader/GDShader.sublime-syntax
+++ b/gdshader/GDShader.sublime-syntax
@@ -1,0 +1,227 @@
+%YAML 1.2
+---
+# http://www.sublimetext.com/docs/3/syntax.html
+# Generated from the official godot VSCode tmlanguage.json file, modified to support string paths in #includes and gdshaderinc files
+name: GDShader
+file_extensions:
+  - gdshader
+  - gdshaderinc
+scope: source.gdshader
+contexts:
+  main:
+    - include: any
+  comment:
+    - include: commentLine
+    - include: commentBlock
+  any:
+    - include: comment
+    - include: strings
+    - include: enclosed
+    - include: classifier
+    - include: definition
+    - include: keyword
+    - include: element
+    - include: separator
+    - include: operator
+  arraySize:
+    - match: '\['
+      captures:
+        0: punctuation.bracket.gdshader
+      push:
+        - meta_scope: meta.array-size.gdshader
+        - match: '\]'
+          captures:
+            0: punctuation.bracket.gdshader
+          pop: true
+        - include: comment
+        - include: keyword
+        - include: element
+        - include: separator
+  classifier:
+    - match: (?=\b(?:shader_type|render_mode)\b)
+      push:
+        - meta_scope: meta.classifier.gdshader
+        - match: (?<=;)
+          pop: true
+        - include: comment
+        - include: keyword
+        - include: identifierClassification
+        - include: separator
+  classifierKeyword:
+    - match: \b(?:shader_type|render_mode)\b
+      scope: keyword.language.classifier.gdshader
+  commentBlock:
+    - match: /\*
+      push:
+        - meta_scope: comment.block.gdshader
+        - match: \*/
+          pop: true
+  commentLine:
+    - match: //
+      push:
+        - meta_scope: comment.line.double-slash.gdshader
+        - match: $
+          pop: true
+  constantFloat:
+    - match: \b(?:E|PI|TAU)\b
+      scope: constant.language.float.gdshader
+  constructor:
+    - match: '\b[a-zA-Z_]\w*(?=\s*\[\s*\w*\s*\]\s*[(])|\b[A-Z]\w*(?=\s*[(])'
+      scope: entity.name.type.constructor.gdshader
+  controlKeyword:
+    - match: \b(?:if|else|do|while|for|continue|break|switch|case|default|return|discard)\b
+      scope: keyword.control.gdshader
+  definition:
+    - include: structDefinition
+  element:
+    - include: literalFloat
+    - include: literalInt
+    - include: literalBool
+    - include: identifierType
+    - include: constructor
+    - include: processorFunction
+    - include: identifierFunction
+    - include: swizzling
+    - include: identifierField
+    - include: constantFloat
+    - include: languageVariable
+    - include: identifierVariable
+  enclosed:
+    - match: \(
+      captures:
+        0: punctuation.parenthesis.gdshader
+      push:
+        - meta_scope: meta.parenthesis.gdshader
+        - match: \)
+          captures:
+            0: punctuation.parenthesis.gdshader
+          pop: true
+        - include: any
+  fieldDefinition:
+    - match: '\b[a-zA-Z_]\w*\b'
+      push:
+        - meta_scope: meta.definition.field.gdshader
+        - match: (?<=;)
+          pop: true
+        - include: comment
+        - include: keyword
+        - include: arraySize
+        - include: fieldName
+        - include: any
+  fieldName:
+    - match: '\b[a-zA-Z_]\w*\b'
+      scope: entity.name.variable.field.gdshader
+  hintKeyword:
+    - match: '\b(?:source_color|hint_(?:color|range|(?:black_)?albedo|normal|(?:default_)?(?:white|black)|aniso|anisotropy|roughness_(?:[rgba]|normal|gray))|filter_(?:nearest|linear)(?:_mipmap(?:_anisotropic)?)?|repeat_(?:en|dis)able)\b'
+      scope: support.type.annotation.gdshader
+  identifierClassification:
+    - match: '\b[a-z_]+\b'
+      scope: entity.other.inherited-class.gdshader
+  identifierField:
+    - match: '([.])\s*([a-zA-Z_]\w*)\b(?!\s*\()'
+      captures:
+        1: punctuation.accessor.gdshader
+        2: entity.name.variable.field.gdshader
+  identifierFunction:
+    - match: '\b[a-zA-Z_]\w*(?=(?:\s|/\*(?:\*(?!/)|[^*])*\*/)*[(])'
+      scope: entity.name.function.gdshader
+  identifierType:
+    - match: '\b[a-zA-Z_]\w*(?=(?:\s*\[\s*\w*\s*\])?\s+[a-zA-Z_]\w*\b)'
+      scope: entity.name.type.gdshader
+  identifierVariable:
+    - match: '\b[a-zA-Z_]\w*\b'
+      scope: variable.name.gdshader
+  keyword:
+    - include: classifierKeyword
+    - include: structKeyword
+    - include: controlKeyword
+    - include: modifierKeyword
+    - include: precisionKeyword
+    - include: typeKeyword
+    - include: hintKeyword
+  languageVariable:
+    - match: '\b(?:[A-Z][A-Z_0-9]*)\b'
+      scope: variable.language.gdshader
+  literalBool:
+    - match: \b(?:false|true)\b
+      scope: constant.language.boolean.gdshader
+  literalFloat:
+    - match: '\b(?:\d+[eE][-+]?\d+|(?:\d*[.]\d+|\d+[.])(?:[eE][-+]?\d+)?)[fF]?'
+      scope: constant.numeric.float.gdshader
+  literalInt:
+    - match: '\b(?:0[xX][0-9A-Fa-f]+|\d+[uU]?)\b'
+      scope: constant.numeric.integer.gdshader
+  modifierKeyword:
+    - match: \b(?:const|global|instance|uniform|varying|in|out|inout|flat|smooth)\b
+      scope: storage.modifier.gdshader
+  operator:
+    - match: '\<\<\=?|\>\>\=?|[-+*/&|<>=!]\=|\&\&|[|][|]|[-+~!*/%<>&^|=]'
+      scope: keyword.operator.gdshader
+  precisionKeyword:
+    - match: \b(?:low|medium|high)p\b
+      scope: storage.type.built-in.primitive.precision.gdshader
+  processorFunction:
+    - match: '\b(?:vertex|fragment|light|start|process|sky|fog)(?=(?:\s|/\*(?:\*(?!/)|[^*])*\*/)*[(])'
+      scope: support.function.gdshader
+  separator:
+    - match: "[.]"
+      scope: punctuation.accessor.gdshader
+    - include: separatorComma
+    - match: "[;]"
+      scope: punctuation.terminator.statement.gdshader
+    - match: "[:]"
+      scope: keyword.operator.type.annotation.gdshader
+  separatorComma:
+    - match: "[,]"
+      scope: punctuation.separator.comma.gdshader
+  strings:
+    - match: '"'
+      captures:
+        0: punctuation.string.gdshader
+      push:
+        - meta_scope: string.quoted.gdshader
+        - match: '"'
+          captures:
+            0: punctuation.string.gdshader
+          pop: true
+        - match: \\.
+          scope: constant.character.escape.gdshader
+  structDefinition:
+    - match: (?=\b(?:struct)\b)
+      push:
+        - match: (?<=;)
+          pop: true
+        - include: comment
+        - include: keyword
+        - include: structName
+        - include: structDefinitionBlock
+        - include: separator
+  structDefinitionBlock:
+    - match: '\{'
+      captures:
+        0: punctuation.definition.block.struct.gdshader
+      push:
+        - meta_scope: meta.definition.block.struct.gdshader
+        - match: '\}'
+          captures:
+            0: punctuation.definition.block.struct.gdshader
+          pop: true
+        - include: comment
+        - include: precisionKeyword
+        - include: fieldDefinition
+        - include: keyword
+        - include: any
+  structKeyword:
+    - match: \b(?:struct)\b
+      scope: keyword.other.struct.gdshader
+  structName:
+    - match: '\b[a-zA-Z_]\w*\b'
+      scope: entity.name.type.struct.gdshader
+  swizzling:
+    - match: '([.])\s*([xyzw]{2,4}|[rgba]{2,4}|[stpq]{2,4})\b'
+      captures:
+        1: punctuation.accessor.gdshader
+        2: variable.other.property.gdshader
+  typeKeyword:
+    - match: '\b(?:void|bool|[biu]?vec[234]|u?int|float|mat[234]|[iu]?sampler(?:3D|2D(?:Array)?)|samplerCube)\b'
+      scope: support.type.gdshader


### PR DESCRIPTION
Made sure to leave only the sublime-syntax files this time!

I also modified the gdshader definition so that it displays properly with #include paths, since I use shader includes a lot and it was bothering me:
![image](https://github.com/user-attachments/assets/2a228c8a-9d97-4fb5-8449-025ede9e89ad)
