### PR TITLE
fixing comment pop breaking function args comments in some cases

### DIFF
--- a/gdscript/GDScript.sublime-syntax
+++ b/gdscript/GDScript.sublime-syntax
@@ -25,7 +25,7 @@ contexts:
     - meta_scope: comment
     - include: special-comments
     - match: \n
-      pop: 2
+      pop: 1
 
   special-comments:
     - match: ({{red_comments}})


### PR DESCRIPTION
I've been running into an issue where certain comments get the syntax highlighting broken sometimes, see these comments after the function args:
![image](https://github.com/user-attachments/assets/d3643a8c-102e-4408-8817-fb65184a395d)

it seems to only be an issue after this commit https://github.com/dementive/SublimeGodot/commit/76fb568245915f36d0409c3c9bd2f1fa59680958

I'm not very knowledgeable about the specifics, but I managed to track it down to this line and it seems to have fixed it:

https://github.com/dementive/SublimeGodot/commit/76fb568245915f36d0409c3c9bd2f1fa59680958#diff-a24b524147cf62a7b85c47052956e781d1c085dda4e81a83bd6a7d649b8e8132R28

![image](https://github.com/user-attachments/assets/88835078-ccbf-4fd3-b39d-00d204d66988)

However, I don't actually know if this will be break anything else. Doesn't seem to, but please let me know otherwise!